### PR TITLE
Implement a config file and loading them into state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,14 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_yaml",
+ "toml",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "hashbrown"
@@ -23,13 +30,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -83,12 +106,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "ryu",
  "serde",
  "yaml-rust",
@@ -106,10 +138,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml = "0.8.26"
+toml = "0.9.5"

--- a/README.md
+++ b/README.md
@@ -9,5 +9,8 @@ Building a tool to sync my blog content with my Obsidian vault. Selectively choo
  - [X] Check if ready for publishing
  - [X] Copy the files to the destination directory
  - [X] Only copy files in specific folders
- - [ ] Clean up the feedback to user
+ - [ ] Complete config implementation
+ - [ ] Add command line arguments and flags
+ - [ ] Move User I/O to separate function
+ - [ ] Add function docs? Is this idiomatic?
  - [ ] Refactor and modularize the functions

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Building a tool to sync my blog content with my Obsidian vault. Selectively choo
 
 # Todo
  - [X] Prompt for Paths
- - [X] Traverse all folders and their sub-folders.
+ - [X] Traverse all folders and their sub folders.
  - [X] parse files for frontmatter.
  - [X] Check if ready for publishing
  - [X] Copy the files to the destination directory
  - [X] Only copy files in specific folders
  - [ ] Complete config implementation
  - [ ] Add command line arguments and flags
+ - [ ] Write the new paths to the config file if user flags to save
  - [ ] Move User I/O to separate function
  - [ ] Add function docs? Is this idiomatic?
  - [ ] Refactor and modularize the functions

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,6 @@
+# Coopy config settings
+
+[user-config]
+source = ""
+target = ""
+

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,8 @@
 # Coopy config settings
 
 [user-config]
-source = ""
-target = ""
+source = "/home/dev/Documents/ObsidianVaults/MyObsidian"
+target = "/home/dev/Documents/ObsidianVaults/Garden/content"
+folders = ["Blog", "Knowledge Base", "Resources", "Self Learning", "Ramblings", "Tech Resources", "Clippings"]
+forbidden = ["Personal Stuff", "Politics and History", "Finances", "Self Care", "Tasks"]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,20 @@
 // Copy the notes from the target folder containing the correct frontmatter tags.
 
-use serde::{Serialize, Deserialize};
+use crate::util::{build_rel_path, check_file};
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::exit;
 use std::string::String;
 use std::{fs, io};
 
+mod util;
+
 #[derive(Debug, Deserialize)]
 struct Frontmatter {
-    // date: Option<String>,
     publish: Option<bool>,
-    // draft: Option<bool>,
     // tags: Option<Vec<String>>,
+    // draft: Option<bool>,
+    // date: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -137,60 +140,4 @@ fn traverse_folder(start: &Path, relative_path: &str) -> io::Result<Vec<String>>
         tar_files.push(build_rel_path(start, relative_path));
     }
     Ok(tar_files)
-}
-
-/// Build the relative path for a file.
-///
-/// Based on the file's location in the vault, build similar path in the target directory
-/// by concatenating the paths.
-fn build_rel_path(file_name: &Path, rel_path: &str) -> String {
-    if rel_path.is_empty() {
-        file_name.to_string_lossy().to_string()
-    } else {
-        format!("{}/{}", rel_path, file_name.to_string_lossy())
-    }
-}
-
-/// Check that a file's marked for publishing, i,e syncing.
-///
-/// Each Obsidian file has a property `publish` which is a boolean.
-fn check_file(file: &Path) -> bool {
-    if let Some(frontmatter) = parse_obsd_frontmatter(&file) {
-        frontmatter.publish.unwrap_or(false)
-    } else {
-        false
-    }
-}
-
-/// Parse the frontmatter which is often YAML in Obsidian files.
-///
-/// Obsidian uses YAML frontmatter between a set of `---`, read file and serialize the properties.
-fn parse_obsd_frontmatter(file: &Path) -> Option<Frontmatter> {
-    let md_content = match fs::read_to_string(file) {
-        Ok(content) => content,
-        Err(_) => return None,
-    };
-    // Check if not YAML frontmatter
-    if let Some(line) = md_content.lines().next() {
-        if line.trim() != "---" {
-            return None;
-        }
-    }
-    let mut matter = String::new();
-    let mut first_line = true;
-    for line in &mut md_content.lines() {
-        if first_line {
-            first_line = false;
-            continue;
-        } else if line.trim() == "---" {
-            break;
-        }
-        matter.push_str(line);
-        matter.push_str("\n");
-    }
-    let frontmatter: Frontmatter = match serde_yaml::from_str(&matter) {
-        Ok(fm) => fm,
-        Err(_) => return None,
-    };
-    Some(frontmatter)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@
 
 use serde::Deserialize;
 use std::path::Path;
+use std::process::exit;
 use std::string::String;
 use std::{fs, io};
-use std::process::exit;
 
 #[derive(Debug, Deserialize)]
 struct Frontmatter {
@@ -13,7 +13,6 @@ struct Frontmatter {
     // draft: Option<bool>,
     // tags: Option<Vec<String>>,
 }
-
 
 #[derive(Deserialize)]
 struct Config {
@@ -25,7 +24,6 @@ struct UserConf {
     source: String,
     target: String,
 }
-
 
 const FOLDERS: [&str; 7] = [
     "Blog",
@@ -46,14 +44,10 @@ const FORBIDDEN: [&str; 5] = [
 
 const CONFIG_FILE: &str = "config.toml";
 
-// This frontmatter tag to be checked if it's true or false (turn into Enum?)
-// const TAGS: [&str; 1] = ["publish"];
-
 fn main() -> Result<(), io::Error> {
     let source = String::from("/home/dev/Documents/ObsidianVaults/MyObsidian");
     let target = String::from("/home/dev/Documents/ObsidianVaults/Garden/content");
 
-    //TODO: implement the config I/O
     let conf_contents = match fs::read_to_string(CONFIG_FILE) {
         Ok(c) => c,
         Err(_) => {
@@ -63,14 +57,13 @@ fn main() -> Result<(), io::Error> {
     };
 
     // The data gets serialized into a Config Struct including the UserConf struct for user settings.
-    let settings: Config = match toml::from_str(&conf_contents){
+    let settings: Config = match toml::from_str(&conf_contents) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("Error parsing settings from: {}", e);
             exit(1);
         }
     };
-
 
     /*
     TODO
@@ -119,7 +112,6 @@ fn traverse_folder(dir: &Path, relative_path: &str) -> io::Result<Vec<String>> {
     let mut tar_files: Vec<String> = Vec::new();
     if dir.is_dir() {
         for entry in fs::read_dir(dir)? {
-            // TODO: is this idiomatic? Or should I do something else like daisy chaining?
             let current_entry = entry?;
             let path = current_entry.path();
             let entry_name = path.file_name().unwrap().to_string_lossy();
@@ -164,7 +156,6 @@ fn parse_obsd_frontmatter(file: &Path) -> Option<Frontmatter> {
         Ok(content) => content,
         Err(_) => return None,
     };
-
     // Check if not YAML frontmatter
     if let Some(line) = md_content.lines().next() {
         if line.trim() != "---" {
@@ -183,7 +174,6 @@ fn parse_obsd_frontmatter(file: &Path) -> Option<Frontmatter> {
         matter.push_str(line);
         matter.push_str("\n");
     }
-
     let frontmatter: Frontmatter = match serde_yaml::from_str(&matter) {
         Ok(fm) => fm,
         Err(_) => return None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Result<(), io::Error> {
     };
 
     // Prompt for paths if not
-    if settings.user_conf.source == "" && settings.user_conf.target != settings.user_conf.source {
+    if settings.user_config.source == "" && settings.user_config.target == "" {
         println!("Obsidian vault's (source) path.");
         io::stdin()
             .read_line(&mut source)
@@ -79,8 +79,8 @@ fn main() -> Result<(), io::Error> {
             .read_line(&mut target)
             .expect("Error reading target path!");
     } else {
-        source = settings.user_conf.source;
-        target = settings.user_conf.target;
+        source = settings.user_config.source;
+        target = settings.user_config.target;
     }
 
     let formatted_source = source.trim();

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,12 +168,7 @@ fn check_file(file: &Path) -> bool {
 fn parse_obsd_frontmatter(file: &Path) -> Option<Frontmatter> {
     let md_content = match fs::read_to_string(file) {
         Ok(content) => content,
-        Err(e) => {
-            eprintln!(
-                "Error reading Frontmatter from {} : {}",
-                file.file_name().unwrap().to_string_lossy(), e);
-            return None;
-        }
+        Err(_) => return None,
     };
     // Check if not YAML frontmatter
     if let Some(line) = md_content.lines().next() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 // Copy the notes from the target folder containing the correct frontmatter tags.
 
-use serde::Deserialize;
+use serde::{Serialize, Deserialize};
 use std::path::Path;
 use std::process::exit;
 use std::string::String;
@@ -14,13 +14,13 @@ struct Frontmatter {
     // tags: Option<Vec<String>>,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all(serialize = "kebab-case", deserialize = "kebab-case"))]
 struct Config {
     user_config: UserConf,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct UserConf {
     source: String,
     target: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,6 @@ fn main() -> Result<(), io::Error> {
     let targeted_files = current_state.traverse_folder(Path::new(&formatted_source), "")?;
     println!("Copying {} files...", targeted_files.len());
 
-
     let success = sync_files(&targeted_files, &formatted_source, &formatted_target);
     if success {
         println!("Sync completed Successfully!");
@@ -144,13 +143,9 @@ fn sync_files(files: &Vec<String>, src: &String, tgt: &String) -> bool {
             }
         }
 
-        // TODO :  refactor to if let
-        let _copied = match fs::copy(&from, to) {
-            Ok(r) => r,
-            Err(e) => {
-                println!("Error copying the file {}: {}", &from, e);
-                continue;
-            }
+        if let Err(e) = fs::copy(&from, to) {
+            eprintln!("Error copying the file {}: {}", &from, e);
+            continue;
         };
     }
     success

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use std::path::Path;
 use std::string::String;
 use std::{fs, io};
+use std::process::exit;
 
 #[derive(Debug, Deserialize)]
 struct Frontmatter {
@@ -42,12 +43,40 @@ const FORBIDDEN: [&str; 5] = [
     "Self Care",
     "Tasks",
 ];
+
+const CONFIG_FILE: &str = "config.toml";
+
 // This frontmatter tag to be checked if it's true or false (turn into Enum?)
 // const TAGS: [&str; 1] = ["publish"];
 
 fn main() -> Result<(), io::Error> {
     let source = String::from("/home/dev/Documents/ObsidianVaults/MyObsidian");
     let target = String::from("/home/dev/Documents/ObsidianVaults/Garden/content");
+
+    //TODO: implement the config I/O
+    let conf_contents = match fs::read_to_string(CONFIG_FILE) {
+        Ok(c) => c,
+        Err(_) => {
+            eprintln!("Error reading config file: {}", CONFIG_FILE);
+            exit(1);
+        }
+    };
+
+    // The data gets serialized into a Config Struct including the UserConf struct for user settings.
+    let settings: Config = match toml::from_str(&conf_contents){
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error parsing settings from: {}", e);
+            exit(1);
+        }
+    };
+
+
+    /*
+    TODO
+        - If settings loaded -> parse, extract, serialize into struct
+        - else, prompt the user for source and target
+     */
 
     // If you need some user input...
     // let mut source = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,18 +40,21 @@ impl State {
                     util::build_rel_path(Path::new(&entry_name.to_string()), relative_path);
 
                 if path.is_dir() {
+                    let entry_str = entry_name.as_ref();
                     if self
                         .config
                         .user_config
                         .folders
-                        .contains(entry_name.as_ref())
+                        .iter()
+                        .any(|f| f == entry_str)
                         || !self
                             .config
                             .user_config
                             .forbidden
-                            .contains(&entry_name.as_ref())
+                            .iter()
+                            .any(|f| f == entry_str)
                     {
-                        let sub_dirs = traverse_folder(&path, &new_rel_path)?;
+                        let sub_dirs = self.traverse_folder(&path, &new_rel_path)?;
                         tar_files.extend(sub_dirs);
                     }
                 } else if path.is_file() && util::check_file(&path) {
@@ -59,36 +62,19 @@ impl State {
                     tar_files.push(new_rel_path);
                 }
             }
-        } else if start.is_file() && util::check_file(&start) {
+        } else if start.is_file() & &util::check_file(&start) {
             tar_files.push(util::build_rel_path(start, relative_path));
         }
         Ok(tar_files)
     }
 }
 
-// const FOLDERS: [&str; 7] = [
-//     "Blog",
-//     "Knowledge Base",
-//     "Resources",
-//     "Self Learning",
-//     "Ramblings",
-//     "Tech Resources",
-//     "Clippings",
-// ];
-// const FORBIDDEN: [&str; 5] = [
-//     "Personal Stuff",
-//     "Politics and History",
-//     "Finances",
-//     "Self Care",
-//     "Tasks",
-// ];
-
 const CONFIG_FILE: &str = "config.toml";
 
 fn main() -> Result<(), io::Error> {
+    // TODO: Clean this up later
     // let test_src = String::from("/home/dev/Documents/ObsidianVaults/MyObsidian");
     // let test_tgt = String::from("/home/dev/Documents/ObsidianVaults/Garden/content");
-
     let mut source = String::new();
     let mut target = String::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,9 @@ fn main() -> Result<(), io::Error> {
     Ok(())
 }
 
+/// Traverse the given directory.
+///
+/// Recursively traverses the directory for files and checks if they're allowed/forbidden.
 fn traverse_folder(start: &Path, relative_path: &str) -> io::Result<Vec<String>> {
     let mut tar_files: Vec<String> = Vec::new();
     if start.is_dir() {
@@ -136,6 +139,10 @@ fn traverse_folder(start: &Path, relative_path: &str) -> io::Result<Vec<String>>
     Ok(tar_files)
 }
 
+/// Build the relative path for a file.
+///
+/// Based on the file's location in the vault, build similar path in the target directory
+/// by concatenating the paths.
 fn build_rel_path(file_name: &Path, rel_path: &str) -> String {
     if rel_path.is_empty() {
         file_name.to_string_lossy().to_string()
@@ -144,6 +151,9 @@ fn build_rel_path(file_name: &Path, rel_path: &str) -> String {
     }
 }
 
+/// Check that a file's marked for publishing, i,e syncing.
+///
+/// Each Obsidian file has a property `publish` which is a boolean.
 fn check_file(file: &Path) -> bool {
     if let Some(frontmatter) = parse_obsd_frontmatter(&file) {
         frontmatter.publish.unwrap_or(false)
@@ -152,6 +162,9 @@ fn check_file(file: &Path) -> bool {
     }
 }
 
+/// Parse the frontmatter which is often YAML in Obsidian files.
+///
+/// Obsidian uses YAML frontmatter between a set of `---`, read file and serialize the properties.
 fn parse_obsd_frontmatter(file: &Path) -> Option<Frontmatter> {
     let md_content = match fs::read_to_string(file) {
         Ok(content) => content,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,11 @@
 // Copy the notes from the target folder containing the correct frontmatter tags.
 
-use crate::util::{build_rel_path, check_file};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::process::exit;
 use std::string::String;
 use std::{fs, io};
-
 mod util;
-
-#[derive(Debug, Deserialize)]
-struct Frontmatter {
-    publish: Option<bool>,
-    // tags: Option<Vec<String>>,
-    // draft: Option<bool>,
-    // date: Option<String>,
-}
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all(serialize = "kebab-case", deserialize = "kebab-case"))]
@@ -122,7 +112,7 @@ fn traverse_folder(start: &Path, relative_path: &str) -> io::Result<Vec<String>>
             // let current_entry = entry?;
             let path = entry?.path();
             let entry_name = path.file_name().unwrap().to_string_lossy();
-            let new_rel_path = build_rel_path(Path::new(&entry_name.to_string()), relative_path);
+            let new_rel_path = util::build_rel_path(Path::new(&entry_name.to_string()), relative_path);
 
             if path.is_dir() {
                 if FOLDERS.contains(&entry_name.as_ref())
@@ -131,13 +121,13 @@ fn traverse_folder(start: &Path, relative_path: &str) -> io::Result<Vec<String>>
                     let sub_dirs = traverse_folder(&path, &new_rel_path)?;
                     tar_files.extend(sub_dirs);
                 }
-            } else if path.is_file() && check_file(&path) {
+            } else if path.is_file() && util::check_file(&path) {
                 println!("Adding file {}", new_rel_path);
                 tar_files.push(new_rel_path);
             }
         }
-    } else if start.is_file() && check_file(&start) {
-        tar_files.push(build_rel_path(start, relative_path));
+    } else if start.is_file() && util::check_file(&start) {
+        tar_files.push(util::build_rel_path(start, relative_path));
     }
     Ok(tar_files)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,20 @@ struct Frontmatter {
     // draft: Option<bool>,
     // tags: Option<Vec<String>>,
 }
+
+
+#[derive(Deserialize)]
+struct Config {
+    user_conf: UserConf,
+}
+
+#[derive(Deserialize)]
+struct UserConf {
+    source: String,
+    target: String,
+}
+
+
 const FOLDERS: [&str; 7] = [
     "Blog",
     "Knowledge Base",

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,9 @@ struct Frontmatter {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all(serialize = "kebab-case", deserialize = "kebab-case"))]
 struct Config {
-    user_conf: UserConf,
+    user_config: UserConf,
 }
 
 #[derive(Deserialize)]
@@ -92,7 +93,6 @@ fn main() -> Result<(), io::Error> {
     for file in targeted_files {
         let from = formatted_source.to_string() + "/" + &file;
         let to = formatted_target.to_string() + "/" + &file;
-        println!("{to}");
         // Ensure the parent directory exists
         if let Some(parent) = Path::new(&to).parent() {
             fs::create_dir_all(parent)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copy the notes from target folder containing the correct frontmatter tags.
+// Copy the notes from the target folder containing the correct frontmatter tags.
 
 use serde::Deserialize;
 use std::path::Path;
@@ -45,8 +45,11 @@ const FORBIDDEN: [&str; 5] = [
 const CONFIG_FILE: &str = "config.toml";
 
 fn main() -> Result<(), io::Error> {
-    let source = String::from("/home/dev/Documents/ObsidianVaults/MyObsidian");
-    let target = String::from("/home/dev/Documents/ObsidianVaults/Garden/content");
+    // let test_src = String::from("/home/dev/Documents/ObsidianVaults/MyObsidian");
+    // let test_tgt = String::from("/home/dev/Documents/ObsidianVaults/Garden/content");
+
+    let mut source = String::new();
+    let mut target = String::new();
 
     let conf_contents = match fs::read_to_string(CONFIG_FILE) {
         Ok(c) => c,
@@ -55,7 +58,6 @@ fn main() -> Result<(), io::Error> {
             exit(1);
         }
     };
-
     // The data gets serialized into a Config Struct including the UserConf struct for user settings.
     let settings: Config = match toml::from_str(&conf_contents) {
         Ok(s) => s,
@@ -65,32 +67,29 @@ fn main() -> Result<(), io::Error> {
         }
     };
 
-    /*
-    TODO
-        - If settings loaded -> parse, extract, serialize into struct
-        - else, prompt the user for source and target
-     */
+    // Prompt for paths if not
+    if settings.user_conf.source == "" && settings.user_conf.target != settings.user_conf.source {
+        println!("Obsidian vault's (source) path.");
+        io::stdin()
+            .read_line(&mut source)
+            .expect("Error reading source path!");
+        println!("Target path: ");
+        io::stdin()
+            .read_line(&mut target)
+            .expect("Error reading target path!");
+    } else {
+        source = settings.user_conf.source;
+        target = settings.user_conf.target;
+    }
 
-    // If you need some user input...
-    // let mut source = String::new();
-    // let mut target = String::new();
-    // println!("Obsidian vault's (source) path.");
-    // io::stdin()
-    //     .read_line(&mut source)
-    //     .expect("Error reading source path!");
-    // println!("Target path: ");
-    // io::stdin()
-    //     .read_line(&mut target)
-    //     .expect("Error reading target path!");
+    let formatted_source = source.trim();
+    let formatted_target = target.trim();
 
-    let form_src = source.trim();
-    let form_target = target.trim();
-
-    let targeted_files = traverse_folder(Path::new(form_src), "")?;
+    let targeted_files = traverse_folder(Path::new(formatted_source), "")?;
     println!("Copying {} files...", targeted_files.len());
     for file in targeted_files {
-        let from = form_src.to_string() + "/" + &file;
-        let to = form_target.to_string() + "/" + &file;
+        let from = formatted_source.to_string() + "/" + &file;
+        let to = formatted_target.to_string() + "/" + &file;
         println!("{to}");
         // Ensure the parent directory exists
         if let Some(parent) = Path::new(&to).parent() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,59 @@
+use std::fs;
+use std::path::Path;
+use crate::Frontmatter;
+
+/// Build the relative path for a file.
+///
+/// Based on the file's location in the vault, build similar path in the target directory
+/// by concatenating the paths.
+pub fn build_rel_path(file_name: &Path, rel_path: &str) -> String {
+    if rel_path.is_empty() {
+        file_name.to_string_lossy().to_string()
+    } else {
+        format!("{}/{}", rel_path, file_name.to_string_lossy())
+    }
+}
+
+/// Check that a file's marked for publishing, i,e syncing.
+///
+/// Each Obsidian file has a property `publish` which is a boolean.
+pub fn check_file(file: &Path) -> bool {
+    if let Some(frontmatter) = parse_obsd_frontmatter(&file) {
+        frontmatter.publish.unwrap_or(false)
+    } else {
+        false
+    }
+}
+
+/// Parse the frontmatter which is often YAML in Obsidian files.
+///
+/// Obsidian uses YAML frontmatter between a set of `---`, read file and serialize the properties.
+pub fn parse_obsd_frontmatter(file: &Path) -> Option<Frontmatter> {
+    let md_content = match fs::read_to_string(file) {
+        Ok(content) => content,
+        Err(_) => return None,
+    };
+    // Check if not YAML frontmatter
+    if let Some(line) = md_content.lines().next() {
+        if line.trim() != "---" {
+            return None;
+        }
+    }
+    let mut matter = String::new();
+    let mut first_line = true;
+    for line in &mut md_content.lines() {
+        if first_line {
+            first_line = false;
+            continue;
+        } else if line.trim() == "---" {
+            break;
+        }
+        matter.push_str(line);
+        matter.push_str("\n");
+    }
+    let frontmatter: Frontmatter = match serde_yaml::from_str(&matter) {
+        Ok(fm) => fm,
+        Err(_) => return None,
+    };
+    Some(frontmatter)
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,14 @@
+use serde::Deserialize;
 use std::fs;
 use std::path::Path;
-use crate::Frontmatter;
+
+#[derive(Debug, Deserialize)]
+pub struct Frontmatter {
+    publish: Option<bool>,
+    // tags: Option<Vec<String>>,
+    // draft: Option<bool>,
+    // date: Option<String>,
+}
 
 /// Build the relative path for a file.
 ///


### PR DESCRIPTION
# Overview
I realized having too many constants and variables was ugly and unsustainable, so I decided to make a configuration file, `config.toml`,  to store settings.

Then I used `fs` and `Serde` to read and serialize into structs and load the config into the program's state.
If the necessary configs are missing, the user is prompted to enter them.
## Other changes
- Refactor functions into a separate module, `util.rs`.
- Refactor some expressions to be more idiomatic, removing verbose lines and redundant variables.
- Update README.md's todo list.
- Update the dependencies in `cargo.toml`
- Various fixes and syntactic sugaring.
###Next up: 
- Add support for command line arguments.
- Add option to save to config file, this includes `folder` and `forbidden` arrays.
- More robust user I/O.
